### PR TITLE
macOS Home Directory compatibility fix

### DIFF
--- a/clamshell/shell_utils.py
+++ b/clamshell/shell_utils.py
@@ -35,7 +35,7 @@ def get_home():
     """
     if is_windows():
         return os.environ["USERPROFILE"]
-    return f'/home/{os.environ["USER"]}'
+    return os.environ["HOME"]
 
 
 def get_clear_command():


### PR DESCRIPTION
$HOME should be universal on Linux and UNIX-like operating systems, including macOS.